### PR TITLE
feat: Add remove-codeql and remove-docker-images support to action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,14 @@ inputs:
     description: 'Removes GHC (Haskell) artifacts. (frees a few MBs)'
     required: false
     default: 'false'
+  remove-codeql:
+    description: 'Removes CodeQL Action Bundles. (frees ~5.4 GB)'
+    required: false
+    default: 'false'
+  remove-docker-images:
+    description: 'Removes cached Docker images. (frees ~3 GB)'
+    required: false
+    default: 'false'
 runs:
   using: "composite"
   steps:
@@ -41,6 +49,12 @@ runs:
           if [[ ${{ inputs.remove-haskell }} == 'true' ]]; then
             echo -n "haskell "
           fi
+          if [[ ${{ inputs.remove-codeql }} == 'true' ]]; then
+            echo -n "codeql "
+          fi
+          if [[ ${{ inputs.remove-docker-images }} == 'true' ]]; then
+            echo -n "docker "
+          fi
           echo
 
           echo "Removing unwanted software... "
@@ -52,6 +66,12 @@ runs:
           fi
           if [[ ${{ inputs.remove-haskell }} == 'true' ]]; then
             sudo rm -rf /opt/ghc
+          fi
+          if [[ ${{ inputs.remove-codeql }} == 'true' ]]; then
+            sudo rm -rf /opt/hostedtoolcache/CodeQL
+          fi
+          if [[ ${{ inputs.remove-docker-images }} == 'true' ]]; then
+            sudo docker image prune --all --force
           fi
           echo "... done"
 


### PR DESCRIPTION
Copied the code responsible for these features from [here](https://github.com/easimon/maximize-build-space/blob/master/action.yml).

In the future, it would be very cool if we can set a CI feature that automatically extracts the relevant code changes for removing software, allowing this fork to always stay up to date with the upstream repo. Just an idea of course. 